### PR TITLE
fix: check `active` field when verifying access token

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -130,7 +130,7 @@ describe('test index', () => {
       expect(result.userId).toBe('test');
     });
 
-    it('should throw error', async () => {
+    it('should throw error for bad request/response', async () => {
       const fetchRes = {
         ok: false,
         statusText: 'Bad Request',
@@ -149,7 +149,7 @@ describe('test index', () => {
       expect(configs.fetch).toBeCalledTimes(1);
     });
 
-    it('should return undefined for invalid token', async () => {
+    it('should throw error for invalid token', async () => {
       const fetchRes = {
         ok: true,
         json: () => ({
@@ -163,9 +163,8 @@ describe('test index', () => {
 
       index.config(configs);
 
-      const result = await index.verify('test');
+      await expect(index.verify('test')).rejects.toThrow('Access token is not active.');
       expect(configs.fetch).toBeCalledTimes(1);
-      expect(result).toBeUndefined();
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,6 @@ export interface VerifyOutput {
   updatedAt: string;
 }
 
-active: true;
-
 const _app: Configs = {
   canPassApi: null,
   fetch: null,
@@ -45,16 +43,21 @@ function config(configs: Configs) {
   Object.assign(_app, configs);
 }
 
-async function verify(accessToken: string): Promise<VerifyOutput | undefined> {
+function verify(accessToken: string): Promise<VerifyOutput | undefined> {
   // handle case access-token start with `Bearer <access-token>`
   const _accessToken = accessToken.split(' ')[1] || accessToken;
-  const result = await _app
+
+  return _app
     .fetch(`${_app.canPassApi}/authenticate?access_token=${_accessToken}`)
     .then(checkFetchStatus)
-    .then(res => res.json());
+    .then(res => res.json())
+    .then(res => {
+      if (!res.active) {
+        throw new Error('Access token is not active.');
+      }
 
-  // @ts-ignore
-  return result.active ? (result as VerifyOutput) : undefined;
+      return res as VerifyOutput;
+    });
 }
 
 export interface TokenOutput {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export interface VerifyOutput {
   updatedAt: string;
 }
 
+active: true;
+
 const _app: Configs = {
   canPassApi: null,
   fetch: null,
@@ -43,14 +45,16 @@ function config(configs: Configs) {
   Object.assign(_app, configs);
 }
 
-function verify(accessToken: string): Promise<VerifyOutput> {
+async function verify(accessToken: string): Promise<VerifyOutput | undefined> {
   // handle case access-token start with `Bearer <access-token>`
   const _accessToken = accessToken.split(' ')[1] || accessToken;
-
-  return _app
+  const result = await _app
     .fetch(`${_app.canPassApi}/authenticate?access_token=${_accessToken}`)
     .then(checkFetchStatus)
     .then(res => res.json());
+
+  // @ts-ignore
+  return result.active ? (result as VerifyOutput) : undefined;
 }
 
 export interface TokenOutput {


### PR DESCRIPTION
in `canPass.verify(token)`